### PR TITLE
Verify building alias corresponds to building

### DIFF
--- a/src/lib/types/helpers.ts
+++ b/src/lib/types/helpers.ts
@@ -1,0 +1,16 @@
+import type { Building } from "$lib/types";
+
+/**
+ * Validates that the user's submitted building number is used.
+ *
+ * @param building all valid buildings
+ * @param buildingNumber the building number to ensure existence of
+ * @throws if there exists no building with the requested building number
+ */
+export async function validateBuildingNumberExists(buildings: Building[], buildingNumber: string) {
+	const matchingBuilding = buildings.find((building) => building.number === buildingNumber);
+
+	if (!matchingBuilding) {
+		throw new Error(`No building exists with number ${buildingNumber}`);
+	}
+}

--- a/src/routes/api/aliases/+server.ts
+++ b/src/routes/api/aliases/+server.ts
@@ -1,6 +1,7 @@
 import { logUserAction } from "$lib/server";
 import { insertBuildingAliasIsValid } from "$lib/types/entity/guards";
 import { validateBuildingAliasFields } from "$lib/types/entity/helpers";
+import { validateBuildingNumberExists } from "$lib/types/helpers";
 import { error, json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
@@ -18,6 +19,11 @@ export const POST: RequestHandler = async (event) => {
 	if (insertBuildingAliasIsValid(body)) {
 		try {
 			validateBuildingAliasFields(body);
+
+			await validateBuildingNumberExists(
+				await event.locals.labline.getBuildings(),
+				body.buildingNumber,
+			);
 
 			const insertedBuildingAlias = await event.locals.db.buildingAliases.createBuildingAlias(body);
 

--- a/src/routes/api/aliases/[aliasId]/+server.ts
+++ b/src/routes/api/aliases/[aliasId]/+server.ts
@@ -1,6 +1,7 @@
 import { logUserAction } from "$lib/server";
 import { buildingAliasIsValid } from "$lib/types/entity/guards";
 import { validateBuildingAliasFields } from "$lib/types/entity/helpers";
+import { validateBuildingNumberExists } from "$lib/types/helpers";
 import { error, isHttpError, json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
@@ -28,6 +29,11 @@ export const PUT: RequestHandler = async (event) => {
 			if (aliasId !== body.id) {
 				return error(400, "ID mismatch!");
 			}
+
+			await validateBuildingNumberExists(
+				await event.locals.labline.getBuildings(),
+				body.buildingNumber,
+			);
 
 			const alias = await event.locals.db.buildingAliases.updateBuildingAliasById(aliasId, body);
 


### PR DESCRIPTION
Currently, it is possible to put nonsense in the building number field of a building alias, as long as the nonsense is exactly 4 characters long. Validating that the submitted building number is present in the building data ensures that the alias can actually be used and found via search.