### PR TITLE
Cache labs on server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL = "postgres://root:mysecretpassword@localhost:5432/local"
 
 ABSOLUTE_DIR_PATH = ""
+LABS_CACHE_TTL_MIN = "10"
 
 BYPASS_ACCOUNT_REQUIREMENT = false
 CREATE_ACCOUNT = "example"
@@ -11,6 +12,6 @@ OIDC_CLIENT_SECRET = "e"
 OIDC_USERNAME_CLAIM = "preferred_username"
 
 ADDRESS_HEADER = "x-forwarded-for"
-XFF_DEPTH: = "1"
+XFF_DEPTH = "1"
 
 PUBLIC_UMAMI_ID = "e"

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,11 +8,13 @@ services:
     environment:
       DATABASE_URL: postgres://root:mysecretpassword@labline-db:5432/local
       ABSOLUTE_DIR_PATH: /opt/labline
+      LABS_CACHE_TTL_MIN: 10
+      BYPASS_ACCOUNT_REQUIREMENT: false
+      CREATE_ACCOUNT: exampleusername
       OIDC_DISCOVERY_ENDPOINT: https://example.com/.well-known
       OIDC_CLIENT_ID: example
       OIDC_CLIENT_SECRET: example
       OIDC_USERNAME_CLAIM: preferred_username
-      CREATE_ACCOUNT: exampleusername
       # proxy settings
       ADDRESS_HEADER: x-forwarded-for
       XFF_DEPTH: 1

--- a/src/lib/server/api/Labline.ts
+++ b/src/lib/server/api/Labline.ts
@@ -1,9 +1,10 @@
+import { env } from "$env/dynamic/private";
 import type { Building, FileStats, Lab } from "$lib/types";
 import Papa from "papaparse";
 import { FileHelper } from "./FileHelper";
 
-// 10 minutes
-const CACHE_TTL_MS = 10 * 60 * 1000;
+const ttlMin = env.LABS_CACHE_TTL_MIN ? parseInt(env.LABS_CACHE_TTL_MIN) : 0;
+const cacheTtlMs = ttlMin * 60 * 1000;
 
 const cache: {
 	labs: Lab[] | undefined;
@@ -18,7 +19,7 @@ function cacheIsValid() {
 
 	const nowMs = Date.now();
 
-	return nowMs - cache.lastUpdatedAt < CACHE_TTL_MS;
+	return nowMs - cache.lastUpdatedAt < cacheTtlMs;
 }
 
 /**

--- a/src/routes/labs/+page.server.ts
+++ b/src/routes/labs/+page.server.ts
@@ -16,6 +16,10 @@ export const load = (async ({ fetch, locals }) => {
 	}
 
 	return {
+		// just sending this 2.2k length array to the client takes 80ms of
+		// the 140ms load time :)
+		// could be optimized with a promise, but that wouldn't really
+		// improve the UX as there is already a loading indicator on nav
 		labs,
 		pageTitle: "Search All Labs",
 		pageDescription: "UGA Lab Emergency Contacts for All Labs.",


### PR DESCRIPTION
A large part of the page load time is currently reading and parsing the 2,200 line labs CSV file on every request. Because this file does not often change, it can be cached to drastically speed up many requests.

Environment variable `LABS_CACHE_TTL_MIN` controls how many minutes a file read is good for (suggested default 10).

GET /buildings 92ms -> 10ms
GET /labs 150ms -> 100ms
GET /summary 200ms -> 100ms

I think a lot of the load time for the lab-dependent routes is sending the 2,200 length array to the client - not much to do about that for now.