### PR TITLE
Trim request body fields

### DIFF
--- a/src/routes/api/aliases/+server.ts
+++ b/src/routes/api/aliases/+server.ts
@@ -25,7 +25,10 @@ export const POST: RequestHandler = async (event) => {
 				body.buildingNumber,
 			);
 
-			const insertedBuildingAlias = await event.locals.db.buildingAliases.createBuildingAlias(body);
+			const insertedBuildingAlias = await event.locals.db.buildingAliases.createBuildingAlias({
+				buildingNumber: body.buildingNumber.trim(),
+				alias: body.alias.trim(),
+			});
 
 			if (event.locals.user) {
 				logUserAction(event.locals.user, `Created alias ${body.buildingNumber} -> ${body.alias}`);

--- a/src/routes/api/aliases/[aliasId]/+server.ts
+++ b/src/routes/api/aliases/[aliasId]/+server.ts
@@ -35,7 +35,10 @@ export const PUT: RequestHandler = async (event) => {
 				body.buildingNumber,
 			);
 
-			const alias = await event.locals.db.buildingAliases.updateBuildingAliasById(aliasId, body);
+			const alias = await event.locals.db.buildingAliases.updateBuildingAliasById(aliasId, {
+				buildingNumber: body.buildingNumber.trim(),
+				alias: body.alias.trim(),
+			});
 
 			if (!alias) {
 				return error(404, "Alias not found");

--- a/src/routes/api/users/+server.ts
+++ b/src/routes/api/users/+server.ts
@@ -30,8 +30,8 @@ export const POST: RequestHandler = async (event) => {
 			validateUserFields(reqJson);
 
 			const user = await event.locals.db.users.createUser({
-				username: reqJson.username,
-				name: reqJson.name,
+				username: reqJson.username.trim(),
+				name: reqJson.name.trim(),
 				roles: reqJson.roles,
 			});
 

--- a/src/routes/api/users/[userId]/+server.ts
+++ b/src/routes/api/users/[userId]/+server.ts
@@ -38,8 +38,8 @@ export const PUT: RequestHandler = async (event) => {
 		validateUserFields(reqJson);
 
 		const user = await event.locals.db.users.updateUserWithRolesById(event.params.userId, {
-			username: reqJson.username,
-			name: reqJson.name,
+			username: reqJson.username.trim(),
+			name: reqJson.name.trim(),
 			roles: reqJson.roles,
 		});
 


### PR DESCRIPTION
Previously, a user could input a username, name, building number, or alias name with whitespace on either end like `   helo   `, and it would be saved. This trims all user text fields before insert or update.