### PR TITLE
Show error message on user management forms

### DIFF
--- a/src/routes/admin/aliases/(manageAlias)/[aliasId]/+page.server.ts
+++ b/src/routes/admin/aliases/(manageAlias)/[aliasId]/+page.server.ts
@@ -42,7 +42,7 @@ async function passThroughRequest(
 	event: RequestEvent,
 	path: string,
 	method: "PUT" | "DELETE",
-	errorMessage: string,
+	fallbackErrorMessage: string,
 ) {
 	const formData = await event.request.formData();
 	const body = Object.fromEntries(formData.entries());
@@ -57,7 +57,7 @@ async function passThroughRequest(
 
 	if (!res.ok) {
 		const resBody = await res.json();
-		return fail(res.status, { message: resBody.message || errorMessage });
+		return fail(res.status, { message: resBody.message || fallbackErrorMessage });
 	}
 
 	return redirect(303, "/admin/aliases");

--- a/src/routes/admin/aliases/(manageAlias)/[aliasId]/+page.svelte
+++ b/src/routes/admin/aliases/(manageAlias)/[aliasId]/+page.svelte
@@ -12,7 +12,9 @@
 
 <h3 class="center-align">{data.pageTitle}</h3>
 
-<p class="center-align error-text">{form?.message}</p>
+{#if form?.message}
+	<p class="center-align error-text">{form.message}</p>
+{/if}
 
 <div class="chip">
 	<i>domain</i>

--- a/src/routes/admin/aliases/(manageAlias)/create/+page.svelte
+++ b/src/routes/admin/aliases/(manageAlias)/create/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { enhance } from "$app/forms";
 	import { Input } from "$lib/components";
-	import type { PageProps } from "./$types";
 
-	let { data, form }: PageProps = $props();
+	let { data, form } = $props();
 
 	let buildingNumber = $state("");
 	let matchingBuilding = $derived(

--- a/src/routes/admin/aliases/(manageAlias)/create/+page.svelte
+++ b/src/routes/admin/aliases/(manageAlias)/create/+page.svelte
@@ -13,7 +13,9 @@
 
 <h3 class="center-align">{data.pageTitle}</h3>
 
-<p class="center-align error-text">{form?.message}</p>
+{#if form?.message}
+	<p class="center-align error-text">{form.message}</p>
+{/if}
 
 <div class="chip">
 	<i>domain</i>

--- a/src/routes/admin/users/[userId]/+page.server.ts
+++ b/src/routes/admin/users/[userId]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, redirect } from "@sveltejs/kit";
+import { fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad, RequestEvent } from "./$types";
 
 export const load = (async (event) => {
@@ -56,7 +56,7 @@ async function passThroughRequest(
 
 	if (!res.ok) {
 		const resBody = await res.json();
-		return error(res.status, resBody.message || errorMessage);
+		return fail(res.status, { message: resBody.message || errorMessage });
 	}
 
 	return redirect(303, "/admin/users");

--- a/src/routes/admin/users/[userId]/+page.server.ts
+++ b/src/routes/admin/users/[userId]/+page.server.ts
@@ -34,7 +34,7 @@ async function passThroughRequest(
 	event: RequestEvent,
 	path: string,
 	method: string,
-	errorMessage: string,
+	fallbackErrorMessage: string,
 ) {
 	const formData = await event.request.formData();
 	const username = formData.get("username");
@@ -56,7 +56,7 @@ async function passThroughRequest(
 
 	if (!res.ok) {
 		const resBody = await res.json();
-		return fail(res.status, { message: resBody.message || errorMessage });
+		return fail(res.status, { message: resBody.message || fallbackErrorMessage });
 	}
 
 	return redirect(303, "/admin/users");

--- a/src/routes/admin/users/[userId]/+page.svelte
+++ b/src/routes/admin/users/[userId]/+page.svelte
@@ -2,10 +2,14 @@
 	import { enhance } from "$app/forms";
 	import { Input } from "$lib/components";
 
-	const { data } = $props();
+	const { data, form } = $props();
 </script>
 
 <h3 class="center-align">{data.pageTitle}</h3>
+
+{#if form?.message}
+	<p class="center-align error-text">{form.message}</p>
+{/if}
 
 <form method="POST" action="?/edit" use:enhance>
 	<Input

--- a/src/routes/admin/users/create/+page.server.ts
+++ b/src/routes/admin/users/create/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, redirect } from "@sveltejs/kit";
+import { fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
@@ -34,7 +34,7 @@ export const actions: Actions = {
 
 		if (!res.ok) {
 			const resBody = await res.json();
-			return error(res.status, resBody.message || "Error creating user");
+			return fail(res.status, { message: resBody.message || "Error creating user" });
 		}
 
 		return redirect(303, "/admin/users");

--- a/src/routes/admin/users/create/+page.svelte
+++ b/src/routes/admin/users/create/+page.svelte
@@ -2,10 +2,14 @@
 	import { enhance } from "$app/forms";
 	import { Input } from "$lib/components";
 
-	let { data } = $props();
+	let { data, form } = $props();
 </script>
 
 <h3 class="center-align">{data.pageTitle}</h3>
+
+{#if form?.message}
+	<p class="center-align error-text">{form.message}</p>
+{/if}
 
 <form method="POST" use:enhance>
 	<Input name="username" type="text" autocomplete="off" required label="Username" />


### PR DESCRIPTION
Red error text above the form seems nicer than `Error 400: you messed up`.

![Screenshot_20250328_151244](https://github.com/user-attachments/assets/745f34be-0365-4107-8b8c-2d9527e31547)
